### PR TITLE
change native samplerate, when possible, to avoid aliasing

### DIFF
--- a/src/js/prosystem/Region.js
+++ b/src/js/prosystem/Region.js
@@ -27,6 +27,7 @@ import * as ProSystem from "./ProSystem.js"
 import * as Cartridge from "./Cartridge.js"
 import * as Maria from "./Maria.js"
 import * as Palette from "./Palette.js"
+import * as Webaudio from "../web/audio.js"
 import { Rect } from "./Rect.js"
 
 import N257_PAL_B from '../../palettes/NTSC/JS7800_NTSC_257_Cool-DK.pal'
@@ -270,6 +271,7 @@ function region_Reset() {
        Palette.Load(PAL_PAL_INDEX[palIdx] /*REGION_PALETTE_PAL*/);  // Added check for default - bberlin
     ProSystem.SetFrequency(REGION_FREQUENCY_PAL);
     ProSystem.SetScanlines(REGION_SCANLINES_PAL);
+    Webaudio.reinit(REGION_FREQUENCY_PAL*REGION_SCANLINES_PAL*2);
     //#ifndef WII    
     //tia_size = 624;
     //pokey_size = 624;
@@ -284,6 +286,7 @@ function region_Reset() {
        Palette.Load(NTSC_PAL_INDEX[palIdx] /*REGION_PALETTE_NTSC*/);  // Added check for default - bberlin
     ProSystem.SetFrequency(REGION_FREQUENCY_NTSC);
     ProSystem.SetScanlines(REGION_SCANLINES_NTSC);
+    Webaudio.reinit(REGION_FREQUENCY_NTSC*REGION_SCANLINES_NTSC*2);
     //#ifndef WII    
     //tia_size = 524;
     //pokey_size = 524;

--- a/src/js/web/audio.js
+++ b/src/js/web/audio.js
@@ -2,7 +2,7 @@ import * as Sound from "../prosystem/Sound.js"
 import * as Events from "../events.js"
 
 var SOUNDBUFSIZE = 8192 << 1;
-var DEFAULT_SAMPLE_RATE = 48000;  
+var DEFAULT_SAMPLE_RATE = 31440; // match default rate to NTSC
 
 /** The audio context */
 var audioCtx = null;
@@ -24,6 +24,11 @@ function storeSound(sample, ym, length) {
 
 function init() {
   Sound.SetStoreSoundCallback(storeSound);
+  if (audioCtx && (window.AudioContext || window.webkitAudioContext)) {
+    audioCtx.close();
+    audioCtx=null;
+    audioNode=null;
+  }
 
   if (!audioCtx && (window.AudioContext || window.webkitAudioContext)) {
     console.log('init audio');
@@ -61,7 +66,15 @@ function init() {
   }
 }
 
+function audio_reinit(rate)
+{
+  DEFAULT_SAMPLE_RATE = rate;
+  init();
+}
+
 Events.addListener(new Events.Listener("init", init));
 
-export { }
+export { 
+  audio_reinit as reinit
+}
 


### PR DESCRIPTION
The region code now resets the sample rate to match tia/pokey, on rom load. (when the device supports it)